### PR TITLE
fix: removed change detection

### DIFF
--- a/projects/seb-ng-wizard/src/lib/left-navigation/left-navigation.component.ts
+++ b/projects/seb-ng-wizard/src/lib/left-navigation/left-navigation.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { WizardStep } from '../wizard/wizard-step';
 
 @Component({
@@ -22,7 +22,6 @@ import { WizardStep } from '../wizard/wizard-step';
     </nav>
   `,
   styleUrls: ['./left-navigation.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LeftNavigationComponent {
   @Input()

--- a/projects/seb-ng-wizard/src/lib/top-bar/top-bar.component.ts
+++ b/projects/seb-ng-wizard/src/lib/top-bar/top-bar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'wiz-top-bar',
@@ -17,7 +17,6 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from 
     </div>
   `,
   styleUrls: ['./top-bar.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TopBarComponent {
   @Input()

--- a/projects/seb-ng-wizard/src/lib/wizard/wizard.component.ts
+++ b/projects/seb-ng-wizard/src/lib/wizard/wizard.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, HostBinding, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';
 import { NavigationEnd, Router, RouterEvent } from '@angular/router';
 import { Observable } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
@@ -40,7 +40,6 @@ import { WizardStep } from './wizard-step';
     </div>
   `,
   styleUrls: ['./wizard.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WizardComponent {
   readonly activeStep$: Observable<WizardStep>;


### PR DESCRIPTION
Change detection on push was used to ensure that the component used the data in an immutable fashion. But that was a poor idea. So I removed it.