### PR TITLE
Default step without need for route change

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve seb-ng-wizard-demo --port 4201",
     "prebuild": "rimraf dist",
     "build": "ng build seb-ng-wizard",
     "build:demo": "ng build seb-ng-wizard-demo --prod --base-href /ng-wizard/",

--- a/projects/seb-ng-wizard-demo/src/app/app.component.ts
+++ b/projects/seb-ng-wizard-demo/src/app/app.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { WizardStep } from 'projects/seb-ng-wizard/src/public_api';
 
 @Component({
   selector: 'demo-root',
@@ -16,13 +18,15 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'seb-ng-wizard-demo';
-  steps = [
+  steps: WizardStep[] = [
     { path: '/first', text: 'First step' },
     { path: '/second', text: 'Second step' },
     { path: '/third', text: 'third step' },
   ];
 
-  nav(e: any) {
-    console.log('nav', e);
+  constructor(private router: Router) {}
+
+  nav(e: WizardStep) {
+    this.router.navigateByUrl(e.path);
   }
 }

--- a/projects/seb-ng-wizard-demo/src/app/app.routing-module.ts
+++ b/projects/seb-ng-wizard-demo/src/app/app.routing-module.ts
@@ -8,7 +8,7 @@ const routes: Routes = [
   { path: 'first', component: FirstPageComponent },
   { path: 'second', component: SecondPageComponent },
   { path: 'third', component: ThirdPageComponent },
-  { path: '', pathMatch: 'full', redirectTo: '/second' },
+  // { path: '', pathMatch: 'full', redirectTo: '/second' },
 ];
 
 @NgModule({

--- a/projects/seb-ng-wizard/src/lib/left-navigation/left-navigation.component.spec.ts
+++ b/projects/seb-ng-wizard/src/lib/left-navigation/left-navigation.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { RouterTestingModule } from '@angular/router/testing';
 import { LeftNavigationComponent } from './left-navigation.component';
 
 describe('LeftNavigationComponent', () => {
@@ -8,6 +8,7 @@ describe('LeftNavigationComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [RouterTestingModule.withRoutes([])],
       declarations: [LeftNavigationComponent],
     }).compileComponents();
   }));
@@ -15,6 +16,7 @@ describe('LeftNavigationComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(LeftNavigationComponent);
     component = fixture.componentInstance;
+    component.steps = [];
     fixture.detectChanges();
   });
 

--- a/projects/seb-ng-wizard/src/lib/left-navigation/left-navigation.component.ts
+++ b/projects/seb-ng-wizard/src/lib/left-navigation/left-navigation.component.ts
@@ -14,7 +14,7 @@ import { WizardStep } from '../wizard/wizard-step';
         </label>
       </h3>
       <ol class="left-navigation-list" [class.hidden]="!toggleMenu.checked">
-        <li *ngFor="let step of steps; index as i" [class.active]="step.path === activeStep.path">
+        <li *ngFor="let step of steps; index as i" [class.active]="isActiveStep(step)">
           <a [routerLink]="step.path"></a>
           <a (click)="handleClick(step); toggleMenu.checked = false" [href]="step.path" [innerText]="step.text"></a>
         </li>
@@ -48,5 +48,12 @@ export class LeftNavigationComponent {
   handleClick(step: WizardStep) {
     this.navigate.next(step);
     return false;
+  }
+
+  isActiveStep(step: WizardStep) {
+    if (!step || !this.activeStep) {
+      return false;
+    }
+    return step.path === this.activeStep.path;
   }
 }

--- a/projects/seb-ng-wizard/src/lib/left-navigation/left-navigation.component.ts
+++ b/projects/seb-ng-wizard/src/lib/left-navigation/left-navigation.component.ts
@@ -14,7 +14,7 @@ import { WizardStep } from '../wizard/wizard-step';
         </label>
       </h3>
       <ol class="left-navigation-list" [class.hidden]="!toggleMenu.checked">
-        <li *ngFor="let step of steps; index as i" routerLinkActive="active">
+        <li *ngFor="let step of steps; index as i" [class.active]="step.path === activeStep.path">
           <a [routerLink]="step.path"></a>
           <a (click)="handleClick(step); toggleMenu.checked = false" [href]="step.path" [innerText]="step.text"></a>
         </li>

--- a/projects/seb-ng-wizard/src/lib/wizard/wizard.component.spec.ts
+++ b/projects/seb-ng-wizard/src/lib/wizard/wizard.component.spec.ts
@@ -1,24 +1,64 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { LeftNavigationComponent } from '../left-navigation/left-navigation.component';
+import { TopBarComponent } from '../top-bar/top-bar.component';
+import { WizardStep } from './wizard-step';
 import { WizardComponent } from './wizard.component';
 
 describe('WizardComponent', () => {
   let component: WizardComponent;
   let fixture: ComponentFixture<WizardComponent>;
+  let router: Router;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [WizardComponent],
+      imports: [
+        RouterTestingModule.withRoutes([
+          { path: 'first', component: WizardComponent },
+          { path: 'second', component: WizardComponent },
+          { path: 'third', component: WizardComponent },
+        ]),
+      ],
+      declarations: [WizardComponent, TopBarComponent, LeftNavigationComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(WizardComponent);
     component = fixture.componentInstance;
+    router = TestBed.get(Router);
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('no steps should result in empty text and path', () => {
+    let result;
+    component.activeStep$.subscribe(step => (result = step));
+    expect(result.text).toEqual('');
+    expect(result.path).toEqual('');
+  });
+  it('no navigation should default to first step', () => {
+    component.steps = [
+      { path: '/first', text: 'First step' },
+      { path: '/second', text: 'Second step' },
+      { path: '/third', text: 'third step' },
+    ];
+    let result;
+    component.activeStep$.subscribe(step => (result = step));
+    expect(result.text).toEqual('First step');
+    expect(result.path).toEqual('/first');
+  });
+  it('navigation should trigger step change', async () => {
+    component.steps = [
+      { path: '/first', text: 'First step' },
+      { path: '/second', text: 'Second step' },
+      { path: '/third', text: 'third step' },
+    ];
+    let result;
+    component.activeStep$.subscribe(step => (result = step));
+    await fixture.ngZone.run(() => router.navigate(['/third']));
+
+    expect(result.text).toEqual('third step');
+    expect(result.path).toEqual('/third');
   });
 });

--- a/projects/seb-ng-wizard/src/lib/wizard/wizard.component.ts
+++ b/projects/seb-ng-wizard/src/lib/wizard/wizard.component.ts
@@ -79,7 +79,9 @@ export class WizardComponent {
     this.activeStep$ = navigationEnd.pipe(
       map((e: NavigationEnd) => {
         const url = typeof e.urlAfterRedirects === 'string' ? e.urlAfterRedirects : e.url;
-        return this.steps.find(step => step.path === url) || this.steps[0];
+        return (
+          this.steps.find(step => step.path === url) || (this.steps.length > 0 ? this.steps[0] : { path: '', text: '' })
+        );
       }),
     );
     this.progress$ = navigationEnd.pipe(

--- a/projects/seb-ng-wizard/src/lib/wizard/wizard.component.ts
+++ b/projects/seb-ng-wizard/src/lib/wizard/wizard.component.ts
@@ -79,7 +79,7 @@ export class WizardComponent {
     this.activeStep$ = navigationEnd.pipe(
       map((e: NavigationEnd) => {
         const url = typeof e.urlAfterRedirects === 'string' ? e.urlAfterRedirects : e.url;
-        return this.steps.find(step => step.path === url) || { path: '', text: '' };
+        return this.steps.find(step => step.path === url) || this.steps[0];
       }),
     );
     this.progress$ = navigationEnd.pipe(


### PR DESCRIPTION
If you don´t change the route after open up the wizard the current step will be empty.
This PR uses the snapshot route as default value.