### PR TITLE
Support multiple router outlets

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The properties you should know about are;
 - _hideCloseButton_ a boolean that tells the wizard to hide the close button on the top-right.
 - _lang_ a string that tells the wizard what language it should be displayed in.
 - _useNavbar_ a boolean that tells the wizard to show an optional bootstrap navbar above the wizard. _this requires your application to have [@sebgroup/bootstrap](https://sebgroup.github.io/bootstrap/)_
+- _routerOutletName_ if using a named router outlet for the wizard, the name needs to be sent in under this property.
 
 ## Events
 

--- a/projects/seb-ng-wizard-demo/src/app/app.component.spec.ts
+++ b/projects/seb-ng-wizard-demo/src/app/app.component.spec.ts
@@ -1,3 +1,4 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 
@@ -5,6 +6,7 @@ describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [AppComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
   }));
 

--- a/projects/seb-ng-wizard/src/lib/wizard/wizard.component.spec.ts
+++ b/projects/seb-ng-wizard/src/lib/wizard/wizard.component.spec.ts
@@ -18,6 +18,7 @@ describe('WizardComponent', () => {
           { path: 'first', component: WizardComponent },
           { path: 'second', component: WizardComponent },
           { path: 'third', component: WizardComponent },
+          { path: 'fourth', component: WizardComponent, outlet: 'otherRouterOutlet' },
         ]),
       ],
       declarations: [WizardComponent, TopBarComponent, LeftNavigationComponent],
@@ -60,5 +61,34 @@ describe('WizardComponent', () => {
 
     expect(result.text).toEqual('third step');
     expect(result.path).toEqual('/third');
+  });
+  it('navigation should match against routerOutletName if it has been provided', async () => {
+    component.routerOutletName = 'otherRouterOutlet';
+    component.steps = [
+      { path: 'first', text: 'First step' },
+      { path: 'second', text: 'Second step' },
+      { path: 'third', text: 'third step' },
+      { path: 'fourth', text: 'fourth step' },
+    ];
+    let result;
+    component.activeStep$.subscribe(step => (result = step));
+    await fixture.ngZone.run(() => router.navigate([{ outlets: { otherRouterOutlet: ['fourth'] } }]));
+
+    expect(result.text).toEqual('fourth step');
+    expect(result.path).toEqual('fourth');
+  });
+  it('navigation should not match against routerOutletName if it has not been provided', async () => {
+    component.steps = [
+      { path: 'first', text: 'First step' },
+      { path: 'second', text: 'Second step' },
+      { path: 'third', text: 'third step' },
+      { path: 'fourth', text: 'fourth step' },
+    ];
+    let result;
+    component.activeStep$.subscribe(step => (result = step));
+    await fixture.ngZone.run(() => router.navigate([{ outlets: { otherRouterOutlet: ['fourth'] } }]));
+
+    expect(result.text).not.toEqual('fourth step');
+    expect(result.path).not.toEqual('fourth');
   });
 });

--- a/projects/seb-ng-wizard/src/lib/wizard/wizard.component.ts
+++ b/projects/seb-ng-wizard/src/lib/wizard/wizard.component.ts
@@ -75,6 +75,9 @@ export class WizardComponent implements OnInit {
   @Input()
   lang: 'sv' | 'en';
 
+  @Input()
+  routerOutletName: string;
+
   @Output()
   navigate: EventEmitter<WizardStep> = new EventEmitter(true);
 
@@ -87,7 +90,7 @@ export class WizardComponent implements OnInit {
       navigationEnd.pipe(
         map((e: NavigationEnd) => {
           const url = typeof e.urlAfterRedirects === 'string' ? e.urlAfterRedirects : e.url;
-          return this.steps.find(step => step.path === url);
+          return this.steps.find(step => this.matchesRoute(step, url));
         }),
       ),
       this.currentRoute(),
@@ -104,6 +107,13 @@ export class WizardComponent implements OnInit {
   }
 
   private currentRoute(): Observable<WizardStep> {
-    return of(this.steps.find(step => step.path === this.router.routerState.snapshot.url));
+    return of(this.steps.find(step => this.matchesRoute(step, this.router.routerState.snapshot.url)));
+  }
+
+  private matchesRoute(step: WizardStep, url: string): boolean {
+    if (this.routerOutletName) {
+      return url.includes(`(${this.routerOutletName}:${step.path})`);
+    }
+    return step.path === url;
   }
 }


### PR DESCRIPTION
This PR is to be able to support named router outlets so it's possible to separate the router outlet the wizard use with other possible router outlets in a project.