### PR TITLE
fix: empty title if navigated step does not exist

### DIFF
--- a/projects/seb-ng-wizard/src/lib/wizard/wizard.component.spec.ts
+++ b/projects/seb-ng-wizard/src/lib/wizard/wizard.component.spec.ts
@@ -38,16 +38,17 @@ describe('WizardComponent', () => {
     expect(result.text).toEqual('');
     expect(result.path).toEqual('');
   });
-  it('no navigation should default to first step', () => {
+  it('navigation to step not in steps array should display empty step', async () => {
     component.steps = [
       { path: '/first', text: 'First step' },
       { path: '/second', text: 'Second step' },
-      { path: '/third', text: 'third step' },
     ];
     let result;
     component.activeStep$.subscribe(step => (result = step));
-    expect(result.text).toEqual('First step');
-    expect(result.path).toEqual('/first');
+    await fixture.ngZone.run(() => router.navigate(['/third']));
+
+    expect(result.text).toEqual('');
+    expect(result.path).toEqual('');
   });
   it('navigation should trigger step change', async () => {
     component.steps = [

--- a/projects/seb-ng-wizard/src/lib/wizard/wizard.component.ts
+++ b/projects/seb-ng-wizard/src/lib/wizard/wizard.component.ts
@@ -94,9 +94,7 @@ export class WizardComponent implements OnInit {
         }),
       ),
       this.currentRoute(),
-    ).pipe(
-      map(routerStep => (routerStep ? routerStep : this.steps.length > 0 ? this.steps[0] : { path: '', text: '' })),
-    );
+    ).pipe(map(routerStep => (routerStep ? routerStep : { path: '', text: '' })));
 
     this._progress$ = navigationEnd.pipe(
       map((e: NavigationEnd) => {


### PR DESCRIPTION
We currently have a bug in the wizard that when all the steps are finished we display a result page inside the wizard that it was successful. That result page is not part of the steps in the left panel (and the left panel becomes hidden). Without this change though, the page will display the first wizard step title at the top since the package defaults to the first step if it can't find the step to navigate to instead of an empty step.

![result_step](https://user-images.githubusercontent.com/5517172/80681661-6a99b180-8ac1-11ea-9498-92152c5e9ddc.JPG)

As you can see it says "Lånet" on top of the page. And that is because Lånet is the first step in our wizard.

However I don't know if the logic I removed now is used for something else? I know we did the last code change here but the logic was there before as well but written like this

```
return (
          this.steps.find(step => step.path === url) || (this.steps.length > 0 ? this.steps[0] : { path: '', text: '' })
        );
```
